### PR TITLE
Update L12MatrixFactorizations.ipynb

### DIFF
--- a/L12MatrixFactorizations.ipynb
+++ b/L12MatrixFactorizations.ipynb
@@ -1345,7 +1345,7 @@
     "\n",
     "where $A$ is $n\\times n$, and both $X$ and $B$ have $p$ columns,\n",
     "\n",
-    "* By matrix inversion of $A$ requires $\\sim 2n^3$ flops\n",
+    "* By matrix inversion of $A$ requires $\\sim 2n^3 + 2p n^2$ flops\n",
     "* By LU factorization of $A$ requires $\\sim \\frac{2}{3}n^3 + 2p n^2$ flops"
    ]
   },


### PR DESCRIPTION
The notes state that matrix inversion requires $\sim 2n^3$ flops, while LU factorization requires $\sim \frac{2}{3} n^3 + 2pn^2$ flops. The term $2pn^2$ is added to account for solving each of the $p$ equations, with $p$ potentially being greater than $n$. However, I believe we should also add a $2pn^2$ term to the operation count for the matrix inversion approach. This is because, after finding the inverse matrix $A^{-1}$, we need to perform a matrix multiplication (i.e., $X = A^{-1}B$). The matrix multiplication involves the $n\times n$ matrix $A^{-1}$ and the $n\times p$ matrix $B$, requiring $2pn^2$ flop operations.